### PR TITLE
feat: add support for dot notations in DataObject Relations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 .DS_Store
 .phpunit.result.cache
 composer.lock
+.idea

--- a/src/Reflection/MethodClassReflectionExtension.php
+++ b/src/Reflection/MethodClassReflectionExtension.php
@@ -147,8 +147,11 @@ class MethodClassReflectionExtension implements MethodsClassReflectionExtension,
                         }
                     }
                     // Ignore parameters
-                    $type = explode('(', $type, 2);
-                    $type = $type[0];
+                    $type = explode('(', $type, 2)[0];
+
+                    // Ignore dot notation such as 'MyClass::class.MyField'
+                    $type = explode('.', $type, 2)[0];
+
                     $componentMethodClass = new $componentClass($methodName, $classReflection, new ObjectType($type));
                     $methods[strtolower($methodName)] = $componentMethodClass;
                 }


### PR DESCRIPTION
When defining ORFM relation we can add the Target Field on the `other` side with dot notation. This breaks class resolution and the relation is unusable.

This PR only pics the class side of the relation definition